### PR TITLE
Add ava-rethinkdb

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,13 +36,13 @@
 - [vim-ava-snippets](https://github.com/ahmedelgabri/vim-ava-snippets) - Snippets for Vim.
 - [ava-spec](https://github.com/sheerun/ava-spec) - Drop-in BDD helpers.
 - [redux-ava](https://github.com/sotojuan/redux-ava) - Test helpers for Redux.
-- [ava-rethinkdb](https://github.com/rrdelaney/ava-rethinkdb) - Test helpers for RethinkDB.
 - [redux-test-recorder](https://github.com/conorhastings/redux-test-recorder) - Generate AVA tests for Redux reducers in a React app.
 - [gulp-ava](https://github.com/avajs/gulp-ava) - Run tests with Gulp.
 - [grunt-ava](https://github.com/avajs/grunt-ava) - Run tests with Grunt.
 - [fly-ava](https://github.com/pine/fly-ava) - Run tests with Fly.
 - [start-ava](https://github.com/start-runner/ava) - Run tests with Start.
 - [sigh-ava](https://github.com/unlight/sigh-ava) - Run tests with Sigh.
+- [ava-rethinkdb](https://github.com/rrdelaney/ava-rethinkdb) - Test helpers for RethinkDB.
 
 
 ## Works with AVA

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,7 @@
 - [vim-ava-snippets](https://github.com/ahmedelgabri/vim-ava-snippets) - Snippets for Vim.
 - [ava-spec](https://github.com/sheerun/ava-spec) - Drop-in BDD helpers.
 - [redux-ava](https://github.com/sotojuan/redux-ava) - Test helpers for Redux.
+- [ava-rethinkdb](https://github.com/rrdelaney/ava-rethinkdb) - Test helpers for RethinkDB.
 - [redux-test-recorder](https://github.com/conorhastings/redux-test-recorder) - Generate AVA tests for Redux reducers in a React app.
 - [gulp-ava](https://github.com/avajs/gulp-ava) - Run tests with Gulp.
 - [grunt-ava](https://github.com/avajs/grunt-ava) - Run tests with Grunt.


### PR DESCRIPTION
This adds [ava-rethinkdb](https://github.com/rrdelaney/ava-rethinkdb) to the list of packages. This package helps spin up and down RethinkDB instances for each test file such that the application code does not need to be modified at all. It's great for integration tests because it allows them to be run in parallel.
