### PR TITLE
add package ava-browser-fixture

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -53,6 +53,7 @@
 
 - [Spectron](https://github.com/electron/spectron#with-ava) - Test Electron apps using AVA and ChromeDriver.
 - [Chūhai](https://github.com/Hypercubed/chuhai) - Run and verify benchmarks using AVA and benchmark.js.
+- [ava-browser-fixture](https://www.npmjs.com/package/ava-browser-fixture) - Run browser-based specs with ava inside browser-env, as suggested in [browser-testing](https://github.com/avajs/ava/blob/master/docs/recipes/browser-testing.md)
 
 
 ## Tutorials & Workshops


### PR DESCRIPTION
Hi,

I wrote a little helper to add browser-testing with `ava` and `browser-env`, as already suggested in the docs: https://github.com/avajs/ava/blob/master/docs/recipes/browser-testing.md

Package: https://www.npmjs.com/package/ava-browser-fixture
Github: https://github.com/WeltN24/ava-browser-fixture

( I added the npmjs.org link - should I better add the github-link?)