### PR TITLE
Remove ava-check

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,7 +51,6 @@
 - [eslint-ava-rule-tester](https://github.com/jfmengels/eslint-ava-rule-tester) - Test [ESLint](https://github.com/eslint/eslint) plugins with AVA.
 - [jscodeshift-ava-tester](https://github.com/jfmengels/jscodeshift-ava-tester) - Test [jscodeshift](https://github.com/facebook/jscodeshift) codemods with AVA.
 - [ava-preact-init](https://github.com/avajs/ava-preact-init) - Set up AVA for Preact.
-- [ava-check](https://github.com/leebyron/testcheck-js/tree/master/integrations/ava-check) - Generative property testing with [`TestCheck.js`](https://github.com/leebyron/testcheck-js).
 - [ava-fixture](https://github.com/unional/ava-fixture) - Run fixture/baseline tests with AVA.
 - [ava-playback](https://github.com/dempfi/ava-playback) - Record and playback HTTP requests.
 


### PR DESCRIPTION
This package does not work with recent ava and is unmaintaned. 
https://github.com/leebyron/testcheck-js/pulls
It's a good package but can it be considered _awesome_?