### PR TITLE
Add bs-ava

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,7 @@
 - [ava-preact-init](https://github.com/avajs/ava-preact-init) - Set up AVA for Preact.
 - [ava-fixture](https://github.com/unional/ava-fixture) - Run fixture/baseline tests with AVA.
 - [ava-playback](https://github.com/dempfi/ava-playback) - Record and playback HTTP requests.
+- [bs-ava](https://github.com/godu/bs-ava) - BuckleScript bindings to AVA.
 
 
 ## Works with AVA


### PR DESCRIPTION
I'm bored to see all reasonml's repo use jest by default.