### PR TITLE
Remove ava-rethinkdb

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,6 @@
 - [fly-ava](https://github.com/pine/fly-ava) - Run tests with Fly.
 - [start-ava](https://github.com/start-runner/ava) - Run tests with Start.
 - [sigh-ava](https://github.com/unlight/sigh-ava) - Run tests with Sigh.
-- [ava-rethinkdb](https://github.com/rrdelaney/ava-rethinkdb) - Test helpers for RethinkDB.
 - [eslint-ava-rule-tester](https://github.com/jfmengels/eslint-ava-rule-tester) - Test [ESLint](https://github.com/eslint/eslint) plugins with AVA.
 - [jscodeshift-ava-tester](https://github.com/jfmengels/jscodeshift-ava-tester) - Test [jscodeshift](https://github.com/facebook/jscodeshift) codemods with AVA.
 - [ava-preact-init](https://github.com/avajs/ava-preact-init) - Set up AVA for Preact.


### PR DESCRIPTION
As per [this comment](https://github.com/rrdelaney/ava-rethinkdb/issues/11#issuecomment-671002593) from ava-rethinkdb's creator, ava-rethinkdb should probably not be used.