### PR TITLE
Add pava package

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,7 @@
 - [ava-fixture-docker-db](https://github.com/cdaringe/ava-fixture-docker-db) - Add docker databases to your test contexts.
 - [ava-webcomponents](https://github.com/Wildhoney/ava-webcomponents) - Testing web components via Puppeteer.
 - [ava-tap-json](https://github.com/yovasx2/ava-tap-json) - JSON output with AVA compatibility.
+- [pava](https://github.com/TomerAberbach/pava) - Parameterized testing.
 
 ## Works with AVA
 


### PR DESCRIPTION
The [pava](https://github.com/TomerAberbach/pava) package is a small utility for writing parameterized tests in ava.

It was [suggested](https://github.com/avajs/ava/issues/2414#issuecomment-917641595) I add a link to the package here!